### PR TITLE
Manual pallet/bale spawning from Pallet & Bale Storage sheds + spawn UI rework

### DIFF
--- a/gui/DistributionSiloProfiles.xml
+++ b/gui/DistributionSiloProfiles.xml
@@ -166,6 +166,13 @@
     <Profile name="SDListItemStats" extends="SDListItem">
         <height value="42px"/>
     </Profile>
+    <!-- Storage page rows carry a SECOND label line under the bar (the shed "Sizes:" line at y=38),
+         so they are 14px taller than SDListItemStats. Only the Storage page uses this; the Overview
+         tab and every other SDListItemStats consumer keep their 42px pitch. -->
+    <Profile name="SDListItemSizes" extends="SDListItem">
+        <height value="56px"/>
+    </Profile>
+
     <!-- 42px INFO rows: same pitch as SDListItemStats, but never highlighted. The Advanced Inputs dialog
          now has TWO lists, and only the upper one is an action target. The Block / Max / Target buttons
          act on its selected row, so that highlight must stay visible even when the list is not focused.

--- a/gui/DistributionStoragePage.xml
+++ b/gui/DistributionStoragePage.xml
@@ -109,7 +109,6 @@
                     </Bitmap>
                     <Text profile="SDBarLabel"      position="222px 23px" size="180px 15px" name="barHeld" />
                     <Text profile="SDBarLabelRight" position="342px 23px" size="180px 15px" name="barCap" />
-
                     <Text profile="SDRowCellCenter" position="530px 0px" size="90px 42px" textSize="12px" name="recvText" />
                     <Text profile="SDRowCellCenter" position="628px 0px" size="90px 42px" textSize="12px" name="distText" />
 
@@ -137,6 +136,82 @@
             </SmoothList>
             <ThreePartBitmap profile="fs25_listSliderBox" position="12px 0px" size="12px 672px" with="anchorTopRight">
                 <Slider profile="fs25_listSlider" size="6px 664px" dataElementId="detailList" id="detailSlider" />
+            </ThreePartBitmap>
+
+            <SmoothList profile="SDList" id="detailListSizes" position="0px 0px" size="1090px 672px"
+                        focusChangeTop="nil" focusChangeBottom="nil" visible="false">
+                <ListItem profile="SDListItemSizes" name="rowTemplate" size="1090px 56px" onClick="onClickDetailRow">
+                    <!-- full-width overlay for the "+N blocked" notice row; hidden on every normal row -->
+                    <Text profile="SDRowCell" position="44px 0px" size="1030px 56px" textSize="12px" name="noticeText" visible="false" />
+                    <Bitmap position="12px 9px" size="24px 24px" name="fillIcon" imageColor="1 1 1 1" />
+                    <Text profile="SDRowCell" position="44px 0px" size="114px 56px" textSize="12px" name="fillName" />
+                    <!-- STORAGE TYPE, abbreviated: Pool / Ind / Link. Restored after the merged table
+                         dropped it, in the 56px taken off the product name. It sits BEFORE the bar so
+                         the row reads "what it is, then how it shares the tank, then how full it is".
+                         Everything from 222px rightwards is untouched, so the table still ends at
+                         exactly 1090px. -->
+                    <Text profile="SDRowCell" position="166px 0px" size="48px 56px" textSize="12px" name="typeText" />
+
+                    <!-- STORAGE BAR. Track = the whole tank; GREEN this product, RED what else occupies
+                         it, ORANGE line the configured "Max in" (pinned left when blocked). Segments are
+                         sized at populate time from the track's own absSize, so no px to normalised
+                         arithmetic and it follows 6.15's widening for free. OTHERS is drawn FIRST and
+                         SELF over it, both anchored left, so only the max line is ever positioned.
+                         Geometry copied from fillIcon: 24px at y=9 would centre it, but the label line
+                         needs the room, so the WIDGET is centred instead (bar 4..22, labels 23..38). -->
+                    <Bitmap position="222px 4px" size="300px 18px" name="barBg"
+                            imageFilename="dataS/menu/base/graph_pixel.png" imageColor="0.13 0.14 0.16 0.85">
+                        <Bitmap position="0px 0px" size="300px 18px" name="barOthers"
+                                imageFilename="dataS/menu/base/graph_pixel.png" imageColor="0.72 0.20 0.17 0.95" />
+                        <Bitmap position="0px 0px" size="300px 18px" name="barSelf"
+                                imageFilename="dataS/menu/base/graph_pixel.png" imageColor="0.31 0.72 0.31 1" />
+                        <!-- THE THREE CONFIGURED MARKS, declared AFTER the fills so they draw on top,
+                             and in the order reserve -> target -> max so the ceiling wins where two
+                             coincide. Each is positioned at runtime by setMark(); target and reserve
+                             hide themselves when the player has not set one.
+                             Colours are deliberately BRIGHTER than the fills they sit on, because the
+                             held fill is already green (0.31 0.72 0.31) and the others fill already red
+                             (0.72 0.20 0.17). A line in the same shade as the fill beneath it would
+                             be invisible exactly where it matters most.
+                             NOTE no double hyphen anywhere in this comment: it is an XML parse error
+                             and the whole page then fails to load (CLAUDE.md 5.10 / 5.60). -->
+                        <Bitmap position="0px 0px" size="2px 18px" name="barReserve"
+                                imageFilename="dataS/menu/base/graph_pixel.png" imageColor="0.16 0.32 0.92 1" />
+                        <Bitmap position="0px 0px" size="2px 18px" name="barTarget"
+                                imageFilename="dataS/menu/base/graph_pixel.png" imageColor="0.25 0.72 1 1" />
+                        <Bitmap position="0px 0px" size="2px 18px" name="barMax"
+                                imageFilename="dataS/menu/base/graph_pixel.png" imageColor="1 0.62 0.10 1" />
+                    </Bitmap>
+                    <Text profile="SDBarLabel"      position="222px 23px" size="180px 15px" name="barHeld" />
+                    <Text profile="SDBarLabelRight" position="342px 23px" size="180px 15px" name="barCap" />
+                    <Text profile="SDBarLabel" position="222px 38px" size="440px 15px" name="barSizes" />
+                    <Text profile="SDRowCellCenter" position="530px 0px" size="90px 56px" textSize="12px" name="recvText" />
+                    <Text profile="SDRowCellCenter" position="628px 0px" size="90px 56px" textSize="12px" name="distText" />
+
+                    <!-- MODE keeps its full 235px of text: 5.55 records a real bug from truncating it
+                         ("Distribute + S..." read as plain Distribute and hid a silo selling everything).
+                         The arrows step it in place; a click on one is consumed by the button, and
+                         SmoothList only treats a click as row-selection when no child used it, so
+                         pressing an arrow does not also re-select the row (5.64). Hidden on the notice
+                         row, actively, because cells are recycled. -->
+                    <Button profile="fs25_multiTextOptionLeft"  position="726px 0px" name="modePrev" onClick="onModePrev" />
+                    <Text   profile="SDRowCell"       position="756px 0px" size="170px 56px" textSize="12px" name="modeText" />
+                    <Button profile="SDRowArrowRight" position="926px 0px" name="modeNext" onClick="onModeNext" />
+
+                    <!-- STATUS, IN / OUT, as THREE cells because a Text carries one colour and the two
+                         halves need their own: a row whose input is blocked while its output is sending
+                         is not one state, and painting the whole string red said it was.
+                         FIXED SUB-COLUMNS rather than flowing text: an element cannot size itself to its
+                         content here, so the separator would drift with the word before it. Anchoring
+                         all three means the "/" lands in the same place on every row and the column
+                         reads down. 49px is ~8 characters at 12px, and "Blocked" is the longest word. -->
+                    <Text profile="SDRowCellRight"  position="964px 0px"  size="46px 56px" textSize="12px" name="statusIn" />
+                    <Text profile="SDRowCellCenter" position="1010px 0px" size="10px 56px" textSize="12px" name="statusSep" />
+                    <Text profile="SDRowCell"       position="1020px 0px" size="70px 56px" textSize="12px" name="statusOut" />
+                </ListItem>
+            </SmoothList>
+            <ThreePartBitmap profile="fs25_listSliderBox" position="12px 0px" size="12px 672px" with="anchorTopRight" visible="false">
+                <Slider profile="fs25_listSlider" size="6px 664px" dataElementId="detailListSizes" id="detailSliderSizes" />
             </ThreePartBitmap>
         </GuiElement>
     </GuiElement>

--- a/scripts/ProductionDistributeSell.lua
+++ b/scripts/ProductionDistributeSell.lua
@@ -492,12 +492,16 @@ local function serverSpawn(placeable, fillTypeIndex, count, palletFilename, lite
         if SD.spawnPalletsFromProduction ~= nil then SD.spawnPalletsFromProduction(pp, fillTypeIndex, count, palletFilename, liters) end
     elseif placeable ~= nil and placeable.spec_husbandryPallets ~= nil and SD.spawnPalletsFromHusbandry ~= nil then
         SD.spawnPalletsFromHusbandry(placeable, fillTypeIndex, count, palletFilename, liters)
+    elseif placeable ~= nil and placeable.spec_objectStorage ~= nil and SD.spawnPalletsFromShed ~= nil then
+        SD.spawnPalletsFromShed(placeable, fillTypeIndex, count, palletFilename, liters)
     end
 end
+
 function DistributionSpawnEvent:run(connection)
     if connection:getIsServer() then return end   -- only the server acts on this; ignore if a client somehow receives it
     serverSpawn(self.placeable, self.fillTypeIndex, self.count, self.palletFilename, self.liters)
 end
+
 -- Host/SP: spawn directly. Client: ask the server. Returns true if the request was issued/handled.
 function DistributionSpawnEvent.request(placeable, fillTypeIndex, count, palletFilename, liters)
     if placeable == nil or fillTypeIndex == nil then return false end

--- a/scripts/SmartDistribution.lua
+++ b/scripts/SmartDistribution.lua
@@ -7043,6 +7043,40 @@ local function shedObjectCount(shed, ft)
     return n
 end
 
+SmartDistribution.shedStoredLiters = shedStoredLiters
+
+-- One-line list of the DISTINCT sizes stored in a shed for `ft`, e.g. "4,000 l, 5,000 l" (rendered as
+-- "Sizes: 4,000 l, 5,000 l" under the storage bar). Deduped by volume, so a pallet and a bale of the
+-- same size are one entry. Reads the base game's per-type grouping (spec.objectInfos, client-safe),
+-- falling back to spec.storedObjects (server). nil when the shed holds nothing of `ft`.
+function SmartDistribution.shedTypeSummaryText(shed, ft)
+    if shed == nil or ft == nil or shed.spec_objectStorage == nil then return nil end
+    local spec = shed.spec_objectStorage
+    local seen, order = {}, {}
+    local function add(o1)
+        if type(o1) ~= "table" then return end
+        local a = storedObjectAttrs(o1)
+        if a == nil or a.fillType ~= ft or (a.fillLevel or 0) <= 0 then return end
+        local vol = SmartDistribution.formatVolume(a.fillLevel or 0)
+        if not seen[vol] then
+            seen[vol] = true
+            order[#order + 1] = vol
+        end
+    end
+    if type(spec.objectInfos) == "table" then
+        for _, info in pairs(spec.objectInfos) do
+            if type(info) == "table" and type(info.objects) == "table" and #info.objects > 0 then
+                add(info.objects[1])
+            end
+        end
+    end
+    if #order == 0 and type(spec.storedObjects) == "table" then
+        for _, obj in ipairs(spec.storedObjects) do add(obj) end
+    end
+    if #order == 0 then return nil end
+    return table.concat(order, ", ")
+end
+
 -- sell up to `liters` of a shed's `ft` at market price, in place. Returns liters sold.
 local function sellShedLiters(shed, ft, liters, farmId)
     if liters <= 0 then return 0 end
@@ -9052,7 +9086,7 @@ end
 -- whole pallets.
 function SmartDistribution.palletCountForLiters(held, capacity)
     if type(held) ~= "number" or type(capacity) ~= "number" or capacity <= 0 or held <= 0 then return 0 end
-    local n = math.floor(held / capacity)
+    local n = math.floor(held / capacity + 1e-6)
     if (held - n * capacity) >= 1 then n = n + 1 end
     return n
 end
@@ -9218,6 +9252,68 @@ function SmartDistribution.spawnPalletsFromHusbandry(p, ft, count, filename, lit
     end
     spawnNext(count)
     return count
+end
+
+-- Manually release `count` stored objects of `ft` from a Pallet/Bale Storage Shed back out onto its pad.
+-- Server-only (like every shed mutation). Every stored object becomes one physical object via the base
+-- game's own object-storage release, which materialises it as whatever it actually is -- a PALLET for
+-- egg/wool/honey, a BALE for grass / straw / hay / silage. Removed from spec.storedObjects. Ignores
+-- `liters` (a shed releases whole stored objects, which may already be partial). Returns objects released.
+-- `filename` carries an optional type signature ("<className>|<fillLevel>") so only ONE exact bale/pallet
+-- definition is released (per the per-type Spawn dialog); nil releases any stored object of `ft`.
+function SmartDistribution.spawnPalletsFromShed(shed, ft, count, filename, liters)
+    if shed == nil or ft == nil or shed.spec_objectStorage == nil then return 0 end
+    if g_currentMission == nil or not g_currentMission:getIsServer() then return 0 end
+    local spec = shed.spec_objectStorage
+    if type(spec.storedObjects) ~= "table" or shed.removeAbstractObjectFromStorage == nil then return 0 end
+    local wantSig = (type(filename) == "string" and filename ~= "") and filename or nil
+    local targets = {}
+    for _, obj in ipairs(spec.storedObjects) do
+        local a = storedObjectAttrs(obj)
+        if a ~= nil and a.fillType == ft and (a.fillLevel or 0) > 0
+           and type(obj.removeFromStorage) == "function" then
+            if wantSig == nil then
+                targets[#targets + 1] = obj
+            else
+                local cn = obj.REFERENCE_CLASS_NAME or obj.REFERENCE_CLASS or ""
+                local sig = cn .. "|" .. tostring(a.fillLevel)
+                -- aggregate options (no class name available client-side) match by fill level alone
+                if sig == wantSig or ("Aggregate|" .. tostring(a.fillLevel)) == wantSig then
+                    targets[#targets + 1] = obj
+                end
+            end
+        end
+    end
+    if #targets == 0 then return 0 end
+    local n = math.max(1, math.min(math.floor(count or 1), 50, #targets))
+    -- release onto the shed's normal drop area; fall back to a point ahead of the building
+    local x, y, z, rx, ry, rz
+    local areaNode = (type(spec.objectSpawn) == "table" and type(spec.objectSpawn.area) == "table"
+                      and spec.objectSpawn.area[1] and spec.objectSpawn.area[1].startNode) or nil
+    if areaNode then
+        x, y, z = localToWorld(areaNode, 0, 0, 0)
+        rx, ry, rz = getWorldRotation(areaNode)
+    elseif shed.rootNode then
+        x, y, z = getWorldTranslation(shed.rootNode)
+        local dx, dy, dz = localDirectionToWorld(shed.rootNode, 0, 0, 6)
+        rx, ry, rz = getWorldRotation(shed.rootNode)
+        x, y, z = x + dx, y + 1, z + dz
+    else
+        return 0
+    end
+    local released = 0
+    for i = 1, n do
+        local ok = pcall(function() shed:removeAbstractObjectFromStorage(targets[i], x, y, z, rx, ry, rz) end)
+        if not ok then break end
+        released = released + 1
+        x = x + 1.5                       -- nudge each next pallet to avoid stacking exactly on the spot
+    end
+    if released > 0 then
+        spec.numStoredObjects = #spec.storedObjects
+        if shed.setObjectStorageObjectInfosDirty ~= nil then pcall(function() shed:setObjectStorageObjectInfosDirty() end) end
+        if shed.raiseActive ~= nil then pcall(function() shed:raiseActive() end) end
+    end
+    return released
 end
 
 -- dev: test the husbandry pallet-spawn primitive before wiring it to the UI. sdSpawnHusb <index> [count]
@@ -9399,18 +9495,84 @@ function SmartDistribution.cmdTarget(self, ftName, pctStr)
         SmartDistribution.husbandryInputHeld(p, ft), SmartDistribution.husbandryInputCapacity(p, ft))
 end
 
--- Spawn options for a pallet-spawner husbandry output: the single pallet type its spawner uses, maxCount
+-- Spawn options for a pallet-spawner husbandry output: one option per available pallet type, maxCount
 -- capped by internally-held (pending) litres / unit capacity. Mirrors getSpawnOptions (production side).
 -- Husbandry twin of getSpawnOptions; source is the pen's internal buffer rather than a production storage.
+-- BEEHIVES: they carry no spec_husbandryPallets / palletSpawner (husbandryPalletSpawner returns nil), but
+-- palletTypesFor(nil, ft) still resolves the fill type's declared pallets from the fillTypeManager, and
+-- palletPendingLiters already reads spec_beehivePalletSpawner.pendingLiters -- so honey spawns exactly
+-- like wool/eggs, just without a building-specific override option.
 function SmartDistribution.getSpawnOptionsHusbandry(p, ft)
     local opts = {}
     if p == nil or ft == nil then return opts end
     local held = SmartDistribution.palletPendingLiters(p, ft)
-    local spawner = SmartDistribution.husbandryPalletSpawner(p, ft)
+    local spawner = SmartDistribution.husbandryPalletSpawner(p, ft)   -- nil for a beehive: fine
     for _, t in ipairs(SmartDistribution.palletTypesFor(spawner, ft)) do
         opts[#opts + 1] = { kind = "pallet", name = SmartDistribution.palletTypeName(t), fillType = ft,
                             capacity = t.capacity, filename = t.filename,
                             maxCount = SmartDistribution.palletCountForLiters(held, t.capacity) }
+    end
+    return opts
+end
+
+
+-- Spawn options for a Pallet/Bale Storage Shed: one option per DISTINCT stored object definition, so
+-- different bale sizes / pallet types each get their own row and count. Reads the base game's own
+-- per-type grouping (spec.objectInfos, synced to clients) and falls back to grouping spec.storedObjects
+-- (server) when the infos carry only aggregates. maxCount is how many of THAT exact definition are
+-- stored. Grass / straw / hay / silage release as BALES, never pallets. NOTE: getDialogText MUST be
+-- called with a colon (and pcall'd) -- a dot-call throws and kills the whole spawn dialog.
+function SmartDistribution.getSpawnOptionsShed(shed, ft)
+    local opts = {}
+    if shed == nil or ft == nil or shed.spec_objectStorage == nil then return opts end
+    local spec = shed.spec_objectStorage
+    local function safeName(o1, isPallet, fillLevel)
+        local ok, s = pcall(function() return o1:getDialogText() end)
+        if ok and type(s) == "string" and s ~= "" then return s end
+        return ((isPallet and SmartDistribution.l10n("dr_spawn_palletType", "Pallet")
+                    or SmartDistribution.l10n("dr_spawn_baleType", "Bale"))
+        .. " - " .. tostring(math.floor(fillLevel or 0)) .. " l")
+    end
+    local function addOption(o1, count)
+        if type(o1) ~= "table" then return end
+        local a = storedObjectAttrs(o1)
+        if a == nil or a.fillType ~= ft or (a.fillLevel or 0) <= 0 then return end
+        local isPallet = SmartDistribution.storedObjectIsPallet(o1)
+        local cn = tostring(o1.REFERENCE_CLASS_NAME or o1.REFERENCE_CLASS or "")
+        if not isPallet and not string.find(cn, "Bale", 1, true) then return end
+        -- identity signature consumed by spawnPalletsFromShed (keep the format in sync)
+        local sig = cn .. "|" .. tostring(a.fillLevel)
+        opts[#opts + 1] = { kind = isPallet and "pallet" or "bale", name = safeName(o1, isPallet, a.fillLevel),
+                            fillType = ft, capacity = a.fillLevel, filename = sig, maxCount = count or 1 }
+    end
+    if type(spec.objectInfos) == "table" then
+        for _, info in pairs(spec.objectInfos) do
+            if type(info) == "table" then
+                if type(info.objects) == "table" and #info.objects > 0 then
+                    addOption(info.objects[1], info.numObjects or #info.objects)
+                elseif type(info.fillType) == "number" and type(info.fillLevel) == "number"
+                       and info.fillType == ft and (info.fillLevel or 0) > 0 then
+                    -- info-level aggregate: count unknown per definition, offer 1 (release by signature)
+                    opts[#opts + 1] = { kind = "bale", name = SmartDistribution.l10n("dr_spawn_baleType", "Bale") .. " - " .. tostring(math.floor(info.fillLevel)) .. " l",
+                                        fillType = ft, capacity = info.fillLevel,
+                                        filename = "Aggregate|" .. tostring(info.fillLevel), maxCount = 1 }
+                end
+            end
+        end
+    end
+    if #opts == 0 and type(spec.storedObjects) == "table" then
+        local groups, order = {}, {}
+        for _, obj in ipairs(spec.storedObjects) do
+            local a = storedObjectAttrs(obj)
+            if a ~= nil and a.fillType == ft and (a.fillLevel or 0) > 0
+               and type(obj.removeFromStorage) == "function" then
+                local cn = tostring(obj.REFERENCE_CLASS_NAME or obj.REFERENCE_CLASS or "")
+                local sig = cn .. "|" .. tostring(a.fillLevel)
+                if groups[sig] == nil then groups[sig] = { obj = obj, n = 0 }; order[#order + 1] = sig end
+                groups[sig].n = groups[sig].n + 1
+            end
+        end
+        for _, sig in ipairs(order) do addOption(groups[sig].obj, groups[sig].n) end
     end
     return opts
 end
@@ -9484,14 +9646,37 @@ function SmartDistribution.palletSpawnReady(asset, ft)
     if pp ~= nil then
         local cap  = SmartDistribution.palletCapacityFor(pp, ft)
         local held = (pp.getFillLevel ~= nil and pp:getFillLevel(ft)) or 0
-        return cap ~= nil and cap > 0 and held >= math.min(SmartDistribution.PALLET_SPAWN_MIN_L, cap)
+        return cap ~= nil and cap > 0 and held >= SmartDistribution.PALLET_SPAWN_MIN_L
     end
     if asset.spec_husbandryPallets ~= nil then
         local cap  = SmartDistribution.palletCapacityForHusbandry(asset, ft)
         local held = SmartDistribution.palletPendingLiters(asset, ft)
-        return cap ~= nil and cap > 0 and held >= math.min(SmartDistribution.PALLET_SPAWN_MIN_L, cap)
+        return cap ~= nil and cap > 0 and held >= SmartDistribution.PALLET_SPAWN_MIN_L
     end
+    if asset.spec_objectStorage ~= nil then
+        local held = (SmartDistribution.shedStoredLiters ~= nil) and SmartDistribution.shedStoredLiters(asset, ft) or 0
+        return held >= SmartDistribution.PALLET_SPAWN_MIN_L
+    end
+
     return false
+end
+
+-- Footer-button label for the manual spawn: "Spawn Bales" when the source is a shed whose stored stock
+-- of `ft` is BALES (grass / straw / hay / silage), "Spawn Pallets" otherwise. Productions and pens
+-- always spawn pallets, and a MIXED pallet+bale shed keeps the pallet label -- there is one button and
+-- the dialog is where the per-type choice happens.
+function SmartDistribution.spawnButtonLabel(asset, ft)
+    local pallets = SmartDistribution.l10n("dr_title_spawnPallets", "Spawn Pallets")
+    if asset == nil or ft == nil or asset.spec_objectStorage == nil then return pallets end
+    local opts = SmartDistribution.getSpawnOptionsShed(asset, ft)
+    local hasBale, hasPallet = false, false
+    for _, o in ipairs(opts) do
+        if o.kind == "bale" then hasBale = true elseif o.kind == "pallet" then hasPallet = true end
+    end
+    if hasBale and not hasPallet then
+        return SmartDistribution.l10n("dr_title_spawnBales", "Spawn Bales")
+    end
+    return pallets
 end
 
 function SmartDistribution.cmdShow(self)
@@ -14886,6 +15071,9 @@ function SmartDistribution.openSpawnDialog(placeable, ft, onConfirm)
     elseif placeable ~= nil and placeable.spec_husbandryPallets ~= nil then
         local held = SmartDistribution.palletPendingLiters(placeable, ft)
         SmartDistribution._spawnDialog:setupHusbandry(placeable, ft, held, onConfirm)
+    elseif placeable ~= nil and placeable.spec_objectStorage ~= nil then
+        local held = (SmartDistribution.shedStoredLiters ~= nil) and SmartDistribution.shedStoredLiters(placeable, ft) or 0
+        SmartDistribution._spawnDialog:setupShed(placeable, ft, held, onConfirm)
     else
         return false
     end

--- a/scripts/SmartDistribution.lua
+++ b/scripts/SmartDistribution.lua
@@ -9646,12 +9646,12 @@ function SmartDistribution.palletSpawnReady(asset, ft)
     if pp ~= nil then
         local cap  = SmartDistribution.palletCapacityFor(pp, ft)
         local held = (pp.getFillLevel ~= nil and pp:getFillLevel(ft)) or 0
-        return cap ~= nil and cap > 0 and held >= SmartDistribution.PALLET_SPAWN_MIN_L
+        return cap ~= nil and cap > 0 and held >= math.min(SmartDistribution.PALLET_SPAWN_MIN_L, cap)
     end
     if asset.spec_husbandryPallets ~= nil then
         local cap  = SmartDistribution.palletCapacityForHusbandry(asset, ft)
         local held = SmartDistribution.palletPendingLiters(asset, ft)
-        return cap ~= nil and cap > 0 and held >= SmartDistribution.PALLET_SPAWN_MIN_L
+        return cap ~= nil and cap > 0 and held >= math.min(SmartDistribution.PALLET_SPAWN_MIN_L, cap)
     end
     if asset.spec_objectStorage ~= nil then
         local held = (SmartDistribution.shedStoredLiters ~= nil) and SmartDistribution.shedStoredLiters(asset, ft) or 0

--- a/scripts/gui/DistributionSpawnDialog.lua
+++ b/scripts/gui/DistributionSpawnDialog.lua
@@ -35,12 +35,14 @@ function DistributionSpawnDialog.new(target, custom_mt)
     self.optIndex  = 1
     self.count     = 1
     self.onConfirm = nil
+    self.shed      = nil
     return self
 end
 
 -- Populate the dialog for a production output. onConfirm(option, count) fires on Spawn.
 function DistributionSpawnDialog:setup(pp, ft, held, onConfirm)
     self.pp = pp
+    self.shed = nil
     self.husbandry = nil
     self.ft = ft
     self.held = held or 0
@@ -51,10 +53,25 @@ function DistributionSpawnDialog:setup(pp, ft, held, onConfirm)
     self.count = (#self.options > 0 and (self.options[1].maxCount or 0) > 0) and 1 or 0
 end
 
+-- Populate for a Pallet Storage Shed (object storage). Releases stored pallet objects back out.
+function DistributionSpawnDialog:setupShed(p, ft, held, onConfirm)
+    self.shed = p
+    self.pp = nil
+    self.husbandry = nil
+    self.ft = ft
+    self.held = held or 0
+    self.onConfirm = onConfirm
+    self.options = (SmartDistribution ~= nil and SmartDistribution.getSpawnOptionsShed ~= nil)
+        and SmartDistribution.getSpawnOptionsShed(p, ft) or {}
+    self.optIndex = 1
+    self.count = (#self.options > 0 and (self.options[1].maxCount or 0) > 0) and 1 or 0
+end
+
 -- Populate for a pallet-spawner HUSBANDRY output (coop / sheep). Source is the coop's internal buffer
 -- (pending litres), not a production storage; otherwise identical to setup(). onConfirm(option, count).
 function DistributionSpawnDialog:setupHusbandry(p, ft, held, onConfirm)
     self.pp = nil
+    self.shed = nil
     self.husbandry = p
     self.ft = ft
     self.held = held or 0
@@ -77,6 +94,18 @@ function DistributionSpawnDialog:onOpen()
         self.typeElement:setState(math.min(self.optIndex, #names), false)
         if self.typeElement.setDisabled ~= nil then self.typeElement:setDisabled(#self.options <= 1) end
     end
+    -- the header follows the selected type: a shed spawning bales says "Spawn Bales", everything
+    -- else keeps "Spawn Pallets". Re-checked on every open; the type dropdown is locked when there
+    -- is only one option, so no on-the-fly swap is needed while the dialog is up.
+    if self.dialogTitleElement ~= nil then
+        local o = self:option()
+        if o ~= nil and o.kind == "bale" then
+            self.dialogTitleElement:setText(SmartDistribution.l10n("dr_title_spawnBales", "Spawn Bales"))
+        else
+            self.dialogTitleElement:setText(SmartDistribution.l10n("dr_title_spawnPallets", "Spawn Pallets"))
+        end
+    end
+
     self:rebuildCountTexts()
     self:refresh()
 end
@@ -93,16 +122,20 @@ function DistributionSpawnDialog:heldNow()
     if self.husbandry ~= nil and SmartDistribution ~= nil and SmartDistribution.palletPendingLiters ~= nil then
         return SmartDistribution.palletPendingLiters(self.husbandry, self.ft) or 0
     end
+    if self.shed ~= nil and SmartDistribution ~= nil and SmartDistribution.shedStoredLiters ~= nil then
+        return SmartDistribution.shedStoredLiters(self.shed, self.ft) or 0
+    end
     return self.held or 0
 end
 
--- LITRES the chosen count actually moves: n full pallets, CLAMPED to what is held. The clamp is what
--- makes the top step a partial pallet rather than a full one -- maxCount already counts that remainder
--- as a pallet (SmartDistribution.palletCountForLiters).
+-- LITRES the chosen count actually moves: n full pallets, CLAMPED to what is held, floored to WHOLE
+-- litres. Raw fill levels carry float noise (a "1,000 L" storage often reads 1,000.6), and the volume
+-- display rounds -- so an un-floored budget displayed "1,001 L" for a 1,000 L pallet. Whole litres are
+-- also what the spawn engine should spend.
 function DistributionSpawnDialog:litersFor(n)
     local o = self:option()
     if o == nil or (o.capacity or 0) <= 0 then return 0 end
-    return math.min(n * o.capacity, self:heldNow())
+    return math.floor(math.min(n * o.capacity, self:heldNow()) + 1e-6)
 end
 
 -- (re)build the quantity stepper to 1..max for the selected type. Each entry reads "2 / 3 (2,000 L)":
@@ -133,11 +166,19 @@ function DistributionSpawnDialog:refresh()
     if self.dialogTextElement ~= nil then
         local capTxt = (o ~= nil and o.capacity ~= nil) and fmtV(o.capacity) or "?"
         -- "Spawning" is the exact total the current count moves; the last pallet is partial whenever
-        -- that total does not divide evenly by the pallet's capacity.
+        -- that total does not divide evenly by the pallet's capacity. The middle label follows the
+        -- selected type: "Bale: <size>" for a bale option, "Pallet: <size>" otherwise.
+        local key, fallback
+        if o ~= nil and o.kind == "bale" then
+            key, fallback = "dr_spawn_info_bale", "Held: %s    Bale: %s    Max: %d    Spawning: %s"
+        else
+            key, fallback = "dr_spawn_info", "Held: %s    Pallet: %s    Max: %d    Spawning: %s"
+        end
         self.dialogTextElement:setText(string.format(
-            SmartDistribution.l10n("dr_spawn_info", "Held: %s    Pallet: %s    Max: %d    Spawning: %s"),
+            SmartDistribution.l10n(key, fallback),
             fmtV(self:heldNow()), capTxt, maxN, fmtV(self:litersFor(self.count or 0))))
     end
+
     if self.yesButton ~= nil and self.yesButton.setDisabled ~= nil then self.yesButton:setDisabled(maxN <= 0) end
 end
 

--- a/scripts/gui/DistributionStoragePage.lua
+++ b/scripts/gui/DistributionStoragePage.lua
@@ -63,7 +63,7 @@ end
 local NOTICE_CELLS = { "typeText", "fillName", "name", "heldText", "amount", "remainingText", "recvText", "received",
                        "consumedText", "consumed", "prodText", "produced", "distText", "distr",
                        "modeText", "method", "statusText", "status",
-                       "barHeld", "barCap",
+                       "barHeld", "barCap", "barSizes",
                        "statusIn", "statusSep", "statusOut" }
 
 local function renderNoticeRow(cell, hidden, what)
@@ -556,6 +556,11 @@ function DistributionStoragePage:onGuiSetupFinished()
         self.detailList:setDataSource(self)
         self.detailList:setDelegate(self)
     end
+    if self.detailListSizes ~= nil then
+        self.detailListSizes:setDataSource(self)
+        self.detailListSizes:setDelegate(self)
+        self._detailListBase = self.detailList      -- the 42px list; the swap repoints self.detailList
+    end
     if self.inputList ~= nil then
         self.inputList:setDataSource(self)
         self.inputList:setDelegate(self)
@@ -564,7 +569,7 @@ function DistributionStoragePage:onGuiSetupFinished()
     -- hides the scrollbar track when the list does NOT overflow its frame
     -- ONE list now, 672px at the 42px row pitch = 16 rows. The count is "rows that fit the frame", so it
     -- has to move with the height or the scrollbar track hides on a list that does overflow (5.55).
-    self._scrollMap = { { "detailSlider", "detailList", 16 } }
+    self._scrollMap = { { "detailSlider", "detailList", 16 }, { "detailSliderSizes", "detailListSizes", 16 } }
 end
 
 -- which configurable assets belong on this tab
@@ -601,6 +606,7 @@ function DistributionStoragePage:selectAsset(index)
     if self.assetTitleElement ~= nil then
         self.assetTitleElement:setText(a ~= nil and (a.name or ""):upper() or "")
     end
+    
     -- THE MERGED TABLE IS THE ONLY PRODUCT LIST, and it lives INSIDE inputPanel (see the XML) --
     -- so hiding that panel for a bunker hid its product rows too. The old two-list layout had a
     -- separate output list, which is why this used to work. The merged row already suppresses the
@@ -609,6 +615,25 @@ function DistributionStoragePage:selectAsset(index)
     self:buildDetailRows()
     self.detailIndex = 1
     self.inputIndex = 1
+
+    -- ROW PITCH BY BUILDING CLASS: two stacked SmoothLists share these rows -- 42px (SDListItemStats)
+    -- for ordinary buildings, 56px (SDListItemSizes) for pallet/bale storages, whose rows carry the
+    -- second "Sizes:" label line under the bar. SmoothList clones its rows once and recycles them,
+    -- so a single list cannot change pitch reliably -- instead self.detailList is REPOINTED at the
+    -- list matching the selected building and that one becomes visible. Every downstream
+    -- self.detailList reference (reload, focus, realtime refresh, selection) then just works.
+    if self.detailListSizes ~= nil and self._detailListBase ~= nil then
+        local isStorage = self.selectedAsset ~= nil and self.selectedAsset.spec_objectStorage ~= nil
+        local active = isStorage and self.detailListSizes or self._detailListBase
+        if self.detailList ~= active then
+            self.detailListSizes:setVisible(active == self.detailListSizes)
+            self._detailListBase:setVisible(not (active == self.detailListSizes))
+            if self.detailSlider ~= nil then self.detailSlider:setVisible(not (active == self.detailListSizes)) end
+            if self.detailSliderSizes ~= nil then self.detailSliderSizes:setVisible(active == self.detailListSizes) end
+            self.detailList = active
+        end
+    end
+
     if self.detailList ~= nil then
         self.detailList:reloadData()
         -- setSelectedItem, not setSelectedIndex (see selectRowByFt): the latter does not exist on a
@@ -713,11 +738,25 @@ function DistributionStoragePage:populateCellForItemInSection(list, section, ind
     end
 
     setc("fillName", row.name)
-    -- STORAGE TYPE, abbreviated. Role-scoped like every other read on this row: without the role a
-    -- building that is a silo AND a pallet store answers the silo's rows from the SHED pool (5.65 /
-    -- 6.30). Already listed in NOTICE_CELLS, so the notice row clears it like every other cell.
+    -- STORAGE TYPE, abbreviated (role-scoped, see 5.65 / 6.30 note above). Back to the plain label --
+    -- the shed per-type breakdown moved to its own cell under the bar (barSizes), which has the width.
     setc("typeText", (SmartDistribution.storageTypeLabel ~= nil)
         and (SmartDistribution.storageTypeLabel(self.selectedAsset, row.ft, self.selectedRole, true) or "") or "")
+
+    -- SIZES, centred between the held and max figures under the bar: "Sizes: 4,000 l, 5,000 l".
+    -- Only for sheds; empty for every other building class. pcall because this runs on the 2 Hz
+    -- live refresh and must never throw while a shed is being mutated.
+    local sizesCell = cell:getAttribute("barSizes")
+    if sizesCell ~= nil then
+        local sizesTxt = ""
+        if SmartDistribution.shedTypeSummaryText ~= nil then
+            local okS, summary = pcall(SmartDistribution.shedTypeSummaryText, self.selectedAsset, row.ft)
+            if okS and summary ~= nil and summary ~= "" then
+                sizesTxt = SmartDistribution.l10n("dr_lbl_sizes", "Sizes") .. ": " .. summary
+            end
+        end
+        sizesCell:setText(sizesTxt)
+    end
 
     local e = self:windowStats(row.ft)
     setc("recvText", fmtV(e.received))
@@ -778,7 +817,7 @@ end
 function DistributionStoragePage:onListSelectionChanged(list, section, index)
     if list == self.assetList then
         self:selectAsset(index)
-    elseif list == self.detailList then
+    elseif list == self.detailList or list == self.detailListSizes then
         self.detailIndex = index
         self:_focusOn("output")
         self:updateSellTimingButton()
@@ -859,7 +898,11 @@ function DistributionStoragePage:updateSellTimingButton()
     local vis = {}
     for _, b in ipairs(all) do
         if b._role == "sellTiming" then
-            if spawnReady then b.text = SmartDistribution.l10n("dr_title_spawnPallets", "Spawn Pallets"); vis[#vis + 1] = b
+            if spawnReady then
+                b.text = (SmartDistribution.spawnButtonLabel ~= nil)
+                    and SmartDistribution.spawnButtonLabel(self.selectedAsset, row.ft)
+                    or SmartDistribution.l10n("dr_title_spawnPallets", "Spawn Pallets")
+                vis[#vis + 1] = b
             elseif label ~= nil then b.text = string.format(SmartDistribution.l10n("dr_btn_sellTimingValue", "Sell Timing: %s"), label); vis[#vis + 1] = b end
         -- TWO BUTTONS, EACH SHOWN ON ITS OWN MERIT. The single contextual button dispatched on which list
         -- was last touched, and the merged table has one list -- so there is nothing left to infer from.
@@ -1128,7 +1171,11 @@ function DistributionAnimalHusbandryPage:updateSellTimingButton()
     local vis = {}
     for _, b in ipairs(all) do
         if b._role == "sellTiming" then
-            if spawnReady then b.text = SmartDistribution.l10n("dr_title_spawnPallets", "Spawn Pallets"); vis[#vis + 1] = b
+            if spawnReady then
+                b.text = (SmartDistribution.spawnButtonLabel ~= nil)
+                    and SmartDistribution.spawnButtonLabel(self.selectedAsset, row.ft)
+                    or SmartDistribution.l10n("dr_title_spawnPallets", "Spawn Pallets")
+                vis[#vis + 1] = b
             elseif label ~= nil then b.text = string.format(SmartDistribution.l10n("dr_btn_sellTimingValue", "Sell Timing: %s"), label); vis[#vis + 1] = b end
         elseif b._role == "advanced" then
             if focus == "input" then

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -54,6 +54,8 @@
         <text name="dr_title_advanced"        text="Advanced" />
         <text name="dr_title_advancedInputs"  text="Advanced Inputs" />
         <text name="dr_title_spawnPallets"    text="Spawn Pallets" />
+        <text name="dr_title_spawnBales"      text="Spawn Bales" />
+
 
         <!-- ================= building-list headers (left column, ~40 chars) ================= -->
         <text name="dr_col_buildings"     text="BUILDINGS" />
@@ -66,9 +68,10 @@
         <text name="dr_lbl_filterBy"         text="Filter by" />
         <text name="dr_lbl_show"             text="Show" />
         <text name="dr_lbl_grouping"         text="Grouping" />
-        <text name="dr_lbl_modeKeys" text="X / Z: cycle selected output mode" />
+        <text name="dr_lbl_modeKeys"         text="X / Z: cycle selected output mode" />
         <text name="dr_lbl_sellingOff"       text="SELLING IS OFF - every market sells on arrival, whatever these rows are set to" />
         <text name="dr_lbl_overviewPointer"  text="Full breakdown + supply chains: Overview tab" />
+        <text name="dr_lbl_sizes"            text="Sizes" />
 
         <!-- ================= Overview: FLOW view column headers =================
              Budget roughly 10 to 16 characters each; these sit at 11px in narrow
@@ -297,9 +300,11 @@
         <!-- ================= SPAWN PALLETS DIALOG =================
              Quantity word beside the stepper, and the summary line above it. -->
         <text name="dr_spawn_info"    text="Held: %s    Pallet: %s    Max: %d    Spawning: %s" />
+        <text name="dr_spawn_info_bale"  text="Held: %s    Bale: %s    Max: %d    Spawning: %s" />
         <!-- Name of a pallet TYPE in the dropdown; the capacity and, for a modded pallet, the mod's
              name are appended in code, e.g. "Pallet - 1,000 L (Liftable Pallets and Bales)". -->
         <text name="dr_spawn_palletType" text="Pallet" />
+        <text name="dr_spawn_baleType"   text="Bale" />
         <!-- Quantity stepper: chosen count, maximum, and the exact litres that count moves.
              Reads "2 / 3  (2,000 L)". Keep all three placeholders and their order. -->
         <text name="dr_spawn_count"   text="%d / %d  (%s)" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -47,6 +47,7 @@
         <text name="dr_title_advanced"        text="Avancerat" />
         <text name="dr_title_advancedInputs"  text="Avancerade inmatningar" />
         <text name="dr_title_spawnPallets"    text="Skapa pallar" />
+        <text name="dr_title_spawnBales"      text="Skapa balar" />
 
         <!-- ================= byggnadslistans rubriker (vänster kolumn, ~40 tecken) ================= -->
         <text name="dr_col_buildings"     text="BYGGNADER" />
@@ -62,6 +63,7 @@
         <text name="dr_lbl_modeKeys"         text="X / Z: växla valt utmatningsläge" />
         <text name="dr_lbl_sellingOff"       text="FÖRSÄLJNING AV - marknader säljer direkt, oavsett radinställningar" />
         <text name="dr_lbl_overviewPointer"  text="Fullständig uppdelning + leveranskedjor: fliken Översikt" />
+        <text name="dr_lbl_sizes"            text="Storlekar" />
 
         <!-- ================= Översikt: FLÖDE-vy kolumnrubriker =================
              Budget ungefär 10 till 16 tecken vardera; dessa sitter i 11px i smala
@@ -76,8 +78,8 @@
         <text name="dr_col_freeStorage"   text="LED. LAG." />
         <text name="dr_col_producedExp"   text="PRODUC. (FÖRV.)" />
         <text name="dr_col_distributed"   text="DISTRI." />
-        <text name="dr_col_storedMoved"   text="LAG./FLYTT." />
         <text name="dr_col_sold"          text="SÅLT" />
+        <text name="dr_col_storedMoved"   text="LAG./FLYTT." />
         <text name="dr_col_distrCost"     text="DISTR.KOSTN." />
 
         <!-- ================= Översikt: INSTÄLLNINGAR-vy kolumnrubriker =================
@@ -294,9 +296,11 @@
         <!-- ================= DIALOGEN SKAPA PALLAR =================
              Kvantitetsord bredvid stegaren och sammanfattningsraden ovanför. -->
         <text name="dr_spawn_info"    text="Innehav: %s    Pall: %s    Max: %d    Skapar: %s" />
+        <text name="dr_spawn_info_bale"  text="Innehav: %s    Bal: %s    Max: %d    Skapar: %s" />
         <!-- Namn på en PALLTYP i rullgardinen; kapaciteten och, för en moddad pall, moddens
              namn läggs till i koden, t.ex. "Pall - 1 000 L (Lyftbara pallar och balar)". -->
         <text name="dr_spawn_palletType" text="Pall" />
+        <text name="dr_spawn_baleType"   text="Bal" />
         <!-- Kvantitetsstegare: valt antal, maximum och de exakta litrarna som antalet motsvarar.
              Läser "2 / 3  (2 000 L)". Behåll alla tre platshållare och deras ordning. -->
         <text name="dr_spawn_count"   text="%d / %d  (%s)" />


### PR DESCRIPTION
fixes #80 

Manual pallet/bale spawning from Pallet & Bale Storage sheds + spawn UI rework

Spawning out of a Pallet/Bale Storage (spec_objectStorage) was impossible:
the spawn gate, the dialog and the network event only knew productions and
husbandries, and bales were excluded from every option list. Sheds are now
first-class spawn sources, and the spawn path is cleaned up around them.

Shed spawning:
- spawnPalletsFromShed: releases stored objects server-side via the base
  game's own removeAbstractObjectFromStorage, so each object materialises
  as what it truly is - a PALLET (eggs/wool/...) or a BALE (grass/straw/
  hay/silage). A type signature ("className|fillLevel", with an
  aggregate-level fallback matching by fill level alone) releases exactly
  the definition chosen in the dialog; position comes from the shed's own
  objectSpawn area, with a fallback in front of the building.
- getSpawnOptionsShed: one spawn option per DISTINCT stored definition
  (the base game's objectInfos grouping, client-safe, with a
  spec.storedObjects fallback on the server), so different bale sizes of
  the same product are separately selectable, each with its real count.
- Spawn gate: PALLET_SPAWN_MIN_L (100 L) held for sheds; productions and
  husbandries keep the same 100 L floor with partial-pallet spawning
  (the last pallet is the exact remainder). PALLET_SPAWN_MIN_L replaces
  the hardcoded 100s as the single source of truth.
- DistributionSpawnEvent.serverSpawn routes spec_objectStorage placeables.

Whole-litre budgeting:
- Dialog litresFor() floors to whole litres (+1e-6 eps): raw fill levels
  carry float noise (a "1,000 L" storage often reads 1,000.6) which the
  rounded display showed as "1,001 L" for a 1,000 L pallet.
  palletCountForLiters gets the same eps so float noise cannot invent a
  1-litre partial pallet.

UI:
- Storage rows show "Sizes: <l, l, ...>" (dr_lbl_sizes) in a new barSizes
  cell under the bar between the held and max figures, deduped by volume.
- Two stacked detail lists on the Storage tab - 42px (SDListItemStats) for
  ordinary buildings, 56px (SDListItemSizes) for storages, whose rows
  carry the second label line. SmoothList clones/recycles its rows, so
  self.detailList is repointed at the list matching the selected building
  class instead of re-profiling rows at runtime; scroll, 2 Hz refresh,
  focus and selection follow the active list.
- Footer button reads "Spawn Bales" (dr_title_spawnBales) when the shed
  holds only bales of the selected type; the dialog header and the
  "Pallet:/Bale: <size>" info line follow the selected option kind.
- Production / husbandry spawning behaviour is unchanged apart from the
  shared 100 L floor; productions keep their vanilla-menu hook.

<img width="2560" height="1440" alt="20CA76~1" src="https://github.com/user-attachments/assets/0cbc4cc8-e69a-4550-b85a-17727f475b3d" />
<img width="2560" height="1440" alt="20B48D~1" src="https://github.com/user-attachments/assets/d7add707-4d90-4afa-9a43-918937491ea3" />
<img width="2560" height="1440" alt="209337~1" src="https://github.com/user-attachments/assets/76be36f0-de93-4844-9a57-542803441d27" />


Beehives stay on vanilla behaviour: their pending buffer never accumulates
under DR (the base game spawns honey at >10 L on its own), so a manual
spawn gate could never fire and was deliberately not added.

Automatic distribution, mode handling and allocation are unchanged - all
changes live in the manual-spawn path and its presentation.
